### PR TITLE
Fix the `repository` URL value

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/1inuxoid/sourcegraph-open-in-webstorm.git"
+    "url": "https://github.com/1inuxoid/sourcegraph-open-in-webstorm"
   },
   "keywords": [
     "sourcegraph",


### PR DESCRIPTION
👋 The current URL in `package.json` isn't valid. This will fix the URL on the [extension page](https://sourcegraph.com/extensions/dymka/open-in-webstorm) so people can click on the "Repository" link. I checked SG's extensions ([see Datadog](https://sourcegraph.com/extensions/sourcegraph/datadog-metrics)) and saw they start using `https` not `git`.

![Image 2022-02-01 at 1 31 04 PM](https://user-images.githubusercontent.com/398230/152055549-05110f53-16e3-40e6-96ac-deb8780954c8.jpg)

Thanks

